### PR TITLE
Test actions-rs CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,10 @@
 # This workflow runs `cargo check`, `cargo test`, `cargo fmt` and `cargo clippy` when a pull-request is created. The stable toolchain is used for all jobs. See actions-rs for more information: https://github.com/actions-rs
 
-on: [pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 name: Continuous integration
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,66 @@
+# This workflow runs `cargo check`, `cargo test`, `cargo fmt` and `cargo clippy` when a pull-request is created. The stable toolchain is used for all jobs. See actions-rs for more information: https://github.com/actions-rs
+
+on: [pull_request]
+
+name: Continuous integration
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,9 @@ on: [pull_request]
 
 name: Continuous integration
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   check:
     name: Check

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub struct FeedData {
 /// (excluding `sequence` and `timestamp`), then encode the whole message with Bencode and return
 /// the bytes as a `Vec<u8>`.
 pub fn encode(msg: &Msg) -> Result<Vec<u8>> {
+    let testing_ci;
     let content: BendyContent;
     match &msg.content {
         Content::Private(msg) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,6 @@ pub struct FeedData {
 /// (excluding `sequence` and `timestamp`), then encode the whole message with Bencode and return
 /// the bytes as a `Vec<u8>`.
 pub fn encode(msg: &Msg) -> Result<Vec<u8>> {
-    let testing_ci;
     let content: BendyContent;
     match &msg.content {
         Content::Private(msg) => {


### PR DESCRIPTION
Adds CI with [actions-rs](https://github.com/actions-rs). Runs the following commands:

```bash
cargo check
cargo test
cargo fmt --all -- --check
cargo clippy -- -D warnings
```

I realise this is quite a restrictive / strict set of checks but I prefer to have a heavy hand when it comes to enforcing idiomatic code and formatting (not just passing tests), especially for core libraries.

@staltz I welcome any input you have on the configuration side of things.